### PR TITLE
Add PyYAML dependency to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pandas>=1.5
+PyYAML>=6.0


### PR DESCRIPTION
## Summary
- add the missing PyYAML dependency required by the configuration loader

## Testing
- python -m compileall loader

------
https://chatgpt.com/codex/tasks/task_e_68e3f3875afc832c98c942784a3b0f4b