### PR TITLE
Implement structured night shift constraints

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -14,5 +14,19 @@ defaults:
     infermiere: 168
     oss: 168
     caposala: 168
-  max_nights_week: 3
-  max_nights_month: 8
+  night:
+    can_work_night: true
+    max_per_week: 2
+    max_per_month: 8
+roles:
+  infermiere:
+    can_work_night: true
+    night:
+      max_per_week: 2
+      max_per_month: 8
+  oss:
+    can_work_night: true
+  caposala:
+    can_work_night: false
+shift_types:
+  night_codes: ["N"]

--- a/employees.csv
+++ b/employees.csv
@@ -1,4 +1,4 @@
-employee_id,nome,ruolo,reparto,ore_dovute_mese_h,saldo_prog_iniziale_h,max_month_hours_h,max_week_hours_h,max_nights_week,max_nights_month,saturday_count_ytd,sunday_count_ytd,holiday_count_ytd
-E001,Anna Rossi,infermiere,ortopedia,168,-4,,,3,8,0,0,0
-E002,Marco Bianchi,oss,degenza,168,2,,,3,8,0,0,0
-E003,Lucia Verdi,caposala,cardiologia,168,0,,,3,8,0,0,0
+employee_id,nome,ruolo,reparto,ore_dovute_mese_h,saldo_prog_iniziale_h,max_month_hours_h,max_week_hours_h,can_work_night,max_nights_week,max_nights_month,saturday_count_ytd,sunday_count_ytd,holiday_count_ytd
+E001,Anna Rossi,infermiere,ortopedia,168,-4,,,,3,8,0,0,0
+E002,Marco Bianchi,oss,degenza,168,2,,,,3,8,0,0,0
+E003,Lucia Verdi,caposala,cardiologia,168,0,,,,3,8,0,0,0

--- a/loader/__init__.py
+++ b/loader/__init__.py
@@ -80,6 +80,7 @@ def load_all(config_path: str, data_dir: str) -> LoadedData:
     employees_df = load_employees(
         os.path.join(data_dir, "employees.csv"),
         defaults,
+        cfg.get("roles", {}) or {},
         weeks_in_horizon,
         horizon_days,
     )


### PR DESCRIPTION
## Summary
- structure night shift defaults in the configuration with role overrides and shift tags
- merge employee night eligibility and limits from config and per-employee overrides during loading
- update CSV data validation to understand the new defaults hierarchy

## Testing
- python -m scripts.check_data --config config.yaml --data-dir .

------
https://chatgpt.com/codex/tasks/task_e_68e4f85993b8832c9e3b1263379e321f