### PR TITLE
Integrate gap pairs generation into loader outputs

### DIFF
--- a/loader/__main__.py
+++ b/loader/__main__.py
@@ -38,6 +38,7 @@ def main() -> None:
     print(f"- leave days: {len(data.leaves_days_df)}")
     print(f"- history righe: {len(data.history_df)}")
     print(f"- eligibility coppie (turno,ruolo): {len(data.eligibility_df)}")
+    print(f"- gap pairs: {len(data.gap_pairs_df)}")
     if not data.holidays_df.empty:
         print(f"- holidays caricati: {len(data.holidays_df)}")
 
@@ -67,6 +68,7 @@ def main() -> None:
         data.eligibility_df.to_csv(
             os.path.join(outdir, "shift_role_eligibility_processed.csv"), index=False
         )
+        data.gap_pairs_df.to_csv(os.path.join(outdir, "gap_pairs.csv"), index=False)
         print(f"Esportati CSV di debug in: {outdir}")
 
 


### PR DESCRIPTION
## Summary
- compute the gap pairs table during load_all using rest-rule-driven windows
- expose the gap pairs DataFrame via the loader CLI output and debug CSV export

## Testing
- python -m loader --config config.yaml --data-dir .


------
https://chatgpt.com/codex/tasks/task_e_68e52d224650832c8033b8b01833edb6