### PR TITLE
Add calendar enrichment utilities for shift slots

### DIFF
--- a/loader/__init__.py
+++ b/loader/__init__.py
@@ -12,7 +12,7 @@ except ModuleNotFoundError as exc:  # pragma: no cover - messaggio esplicativo
     ) from exc
 
 from .availability import load_availability
-from .calendar import attach_calendar, build_calendar
+from .calendar import attach_calendar, build_calendar, enrich_shift_slots_calendar
 from .config import load_config, load_holidays
 from .coverage import (
     build_slot_requirements,
@@ -195,4 +195,7 @@ __all__ = [
     "LoaderError",
     "LoadedData",
     "load_all",
+    "attach_calendar",
+    "build_calendar",
+    "enrich_shift_slots_calendar",
 ]

--- a/loader/calendar.py
+++ b/loader/calendar.py
@@ -38,18 +38,70 @@ def build_calendar(
 
     holiday_desc_col = pd.Series([""] * len(cal), index=cal.index)
     if holidays_df is not None and not holidays_df.empty:
-        holidays_unique = holidays_df.drop_duplicates(subset=["data"], keep="first")
-        cal = cal.merge(
-            holidays_unique[["data", "descrizione"]].rename(
-                columns={"descrizione": "holiday_desc"}
-            ),
-            on="data",
-            how="left",
-        )
-        holiday_desc_col = cal["holiday_desc"].fillna("")
+        holidays_unique = holidays_df.drop_duplicates(subset=["date"], keep="first")
+        holiday_map = holidays_unique.set_index("date")["name"]
+        holiday_desc_col = cal["data_dt"].map(holiday_map).fillna("")
     cal["holiday_desc"] = holiday_desc_col.astype(str)
     cal["is_weekday_holiday"] = cal["holiday_desc"].str.strip().ne("")
     return cal
+
+
+def enrich_shift_slots_calendar(
+    shift_slots: pd.DataFrame, holidays: pd.DataFrame
+) -> pd.DataFrame:
+    """Restituisce una copia degli slot arricchita con informazioni di calendario."""
+
+    required = {"start_dt", "end_dt"}
+    missing = required - set(shift_slots.columns)
+    if missing:
+        missing_str = ", ".join(sorted(missing))
+        raise ValueError(f"Colonne mancanti in shift_slots: {missing_str}")
+
+    enriched = shift_slots.copy()
+
+    if enriched.empty:
+        enriched["date"] = pd.Series(dtype="object")
+        enriched["end_date"] = pd.Series(dtype="object")
+        enriched["weekday"] = pd.Series(dtype="Int64")
+        enriched["iso_year"] = pd.Series(dtype="Int64")
+        enriched["iso_week"] = pd.Series(dtype="Int64")
+        enriched["week_id"] = pd.Series(dtype="Int64")
+        enriched["duration_hours"] = pd.Series(dtype="float64")
+        enriched["is_weekend"] = pd.Series(dtype="boolean")
+        enriched["is_holiday"] = pd.Series(dtype="boolean")
+        enriched["is_weekend_or_holiday"] = pd.Series(dtype="boolean")
+    else:
+        enriched["date"] = enriched["start_dt"].dt.date
+        enriched["end_date"] = enriched["end_dt"].dt.date
+
+        isocalendar_df = enriched["start_dt"].dt.isocalendar()
+        enriched["iso_year"] = isocalendar_df["year"].astype(int)
+        enriched["iso_week"] = isocalendar_df["week"].astype(int)
+        enriched["weekday"] = enriched["start_dt"].dt.weekday
+        enriched["week_id"] = enriched["iso_year"] * 100 + enriched["iso_week"]
+
+        duration = (enriched["end_dt"] - enriched["start_dt"]).dt.total_seconds() / 3600.0
+        enriched["duration_hours"] = duration
+
+        enriched["is_weekend"] = enriched["weekday"] >= 5
+
+        holiday_dates: set[date] = set()
+        if not holidays.empty and "date" in holidays.columns:
+            normalized_holidays = pd.to_datetime(holidays["date"], errors="coerce")
+            normalized_holidays = normalized_holidays.dropna()
+            if normalized_holidays.dt.tz is not None:
+                normalized_holidays = normalized_holidays.dt.tz_convert(None)
+            holiday_dates = {dt.date() for dt in normalized_holidays.dt.normalize()}
+
+        enriched["is_holiday"] = enriched["date"].isin(holiday_dates)
+        enriched["is_weekend_or_holiday"] = enriched["is_weekend"] | enriched["is_holiday"]
+
+    preferred = [
+        col for col in ["slot_id", "reparto_id", "date", "shift_code"] if col in enriched.columns
+    ]
+    remaining = [c for c in enriched.columns if c not in preferred]
+    ordered_cols = preferred + remaining
+    return enriched[ordered_cols]
 
 
 def attach_calendar(df: pd.DataFrame, cal: pd.DataFrame) -> pd.DataFrame:


### PR DESCRIPTION
## Summary
- normalize holiday loading to return cleaned `date`/`name` records and support legacy column names
- enrich shift slots with calendar metadata and holiday/weekend flags without mutating inputs
- expose calendar helpers from the loader package for easier reuse

## Testing
- python -m compileall -f loader

------
https://chatgpt.com/codex/tasks/task_e_68e628ade3f4832cabbcd0092b3e30d4