### PR TITLE
Allow configuring loader export directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ python -m loader --config config.yaml --data-dir . --export-csv
 ```
 
 I file verranno salvati nella cartella `_expanded` all'interno della directory dati.
+Per scegliere una destinazione alternativa è possibile indicare `--export-dir` (percorso
+assoluto o relativo alla directory dati).
 
 ## Limiti orari caricati per dipendente
 

--- a/loader/__main__.py
+++ b/loader/__main__.py
@@ -11,6 +11,12 @@ def main() -> None:
     ap.add_argument(
         "--export-csv", action="store_true", help="Esporta i DF espansi come CSV di debug"
     )
+    ap.add_argument(
+        "--export-dir",
+        type=str,
+        default=None,
+        help="Cartella di destinazione per i CSV di debug (default: <data-dir>/_expanded)",
+    )
     args = ap.parse_args()
 
     try:
@@ -43,7 +49,13 @@ def main() -> None:
         print(f"- holidays caricati: {len(data.holidays_df)}")
 
     if args.export_csv:
-        outdir = os.path.join(args.data_dir, "_expanded")
+        default_outdir = os.path.join(args.data_dir, "_expanded")
+        if args.export_dir is None:
+            outdir = default_outdir
+        else:
+            outdir = args.export_dir
+            if not os.path.isabs(outdir):
+                outdir = os.path.join(args.data_dir, outdir)
         os.makedirs(outdir, exist_ok=True)
         data.calendar_df.to_csv(os.path.join(outdir, "calendar.csv"), index=False)
         data.month_plan_df.to_csv(os.path.join(outdir, "month_plan_with_calendar.csv"), index=False)


### PR DESCRIPTION
## Summary
- add a `--export-dir` option to the loader CLI to customize the debug CSV destination
- document the new flag in the README for discoverability

## Testing
- python -m loader --help

------
https://chatgpt.com/codex/tasks/task_e_68e632901e64832c9c57ff790fdb6ecd