### PR TITLE
Normalize shift eligibility casing and extend calendar lookback

### DIFF
--- a/loader/__init__.py
+++ b/loader/__init__.py
@@ -128,6 +128,7 @@ def load_all(config_path: str, data_dir: str) -> LoadedData:
     shift_slots_df = build_shift_slots(
         month_plan_df, shifts_df, dept_shift_map_df, defaults
     )
+    shift_slots_df = attach_calendar(shift_slots_df, calendar_df)
 
     groups_total_expanded, groups_role_min_expanded = expand_requirements(
         month_plan_df, groups_df, roles_df

--- a/loader/calendar.py
+++ b/loader/calendar.py
@@ -11,7 +11,8 @@ def build_calendar(
 ) -> pd.DataFrame:
     prev_week_start = start_date - timedelta(days=(start_date.isoweekday() - 1))
     six_days_before = start_date - timedelta(days=6)
-    cal_start = min(prev_week_start, six_days_before)
+    cal_start_base = min(prev_week_start, six_days_before)
+    cal_start = cal_start_base - timedelta(days=4)
     rows = []
     d = cal_start
     while d <= end_date:

--- a/loader/shifts.py
+++ b/loader/shifts.py
@@ -427,8 +427,8 @@ def load_shift_role_eligibility(
     df = pd.read_csv(path, dtype=str).fillna("")
     _ensure_cols(df, {"shift_id", "ruolo"}, "shift_role_eligibility.csv")
 
-    df["shift_id"] = df["shift_id"].astype(str).str.strip()
-    df["ruolo"] = df["ruolo"].astype(str).str.strip()
+    df["shift_id"] = df["shift_id"].astype(str).str.strip().str.upper()
+    df["ruolo"] = df["ruolo"].astype(str).str.strip().str.upper()
 
     if (df["shift_id"] == "").any():
         bad = df.loc[df["shift_id"] == "", :].index.tolist()[:5]
@@ -442,8 +442,10 @@ def load_shift_role_eligibility(
         )
 
     # Usa config come fonte di verità per i ruoli ammessi
-    allowed_roles = _resolve_allowed_roles(defaults, fallback_roles=employees_df["ruolo"].unique())
-    known_roles = set(allowed_roles)
+    allowed_roles = _resolve_allowed_roles(
+        defaults, fallback_roles=employees_df["ruolo"].unique()
+    )
+    known_roles = {str(role).strip().upper() for role in allowed_roles}
     bad_roles = sorted(set(df["ruolo"].unique()) - known_roles)
     if bad_roles:
         raise LoaderError(
@@ -451,7 +453,7 @@ def load_shift_role_eligibility(
             f"{bad_roles}"
         )
 
-    known_shifts = set(shifts_df["shift_id"].unique())
+    known_shifts = {str(shift).strip().upper() for shift in shifts_df["shift_id"].unique()}
     bad_shifts = sorted(set(df["shift_id"].unique()) - known_shifts)
     if bad_shifts:
         raise LoaderError(


### PR DESCRIPTION
## Summary
- normalize shift-role eligibility inputs to uppercase before validation
- attach calendar metadata to generated shift slots during load
- extend the generated calendar lookback by four additional days

## Testing
- python -m compileall loader

------
https://chatgpt.com/codex/tasks/task_e_68e63af4ed50832ca25f2b2fc327d21d