### PR TITLE
Respect configured absence hours and modernize dtype checks

### DIFF
--- a/loader/__init__.py
+++ b/loader/__init__.py
@@ -87,6 +87,7 @@ def load_all(config_path: str, data_dir: str) -> LoadedData:
     end_date = _parse_date(cfg["horizon"]["end_date"])
 
     defaults = cfg.get("defaults", {})
+    absence_hours_h = get_absence_hours_from_config(cfg)
 
     holidays_df = load_holidays(os.path.join(data_dir, "holidays.csv"))
 
@@ -182,6 +183,7 @@ def load_all(config_path: str, data_dir: str) -> LoadedData:
         employees_df,
         shifts_df,
         calendar_df,
+        absence_hours_h=absence_hours_h,
     )
     availability_df = load_availability(
         os.path.join(data_dir, "availability.csv"),

--- a/loader/gap_pairs.py
+++ b/loader/gap_pairs.py
@@ -34,7 +34,7 @@ def _normalise(series: pd.Series) -> pd.Series:
 def _to_naive_utc(series: pd.Series) -> pd.Series:
     """Converte una serie datetime tz-aware in naive su UTC."""
 
-    if not pd.api.types.is_datetime64tz_dtype(series):
+    if not isinstance(series.dtype, pd.DatetimeTZDtype):
         raise TypeError("Le colonne start_dt e end_dt devono essere datetime tz-aware")
     return series.dt.tz_convert("UTC").dt.tz_localize(None)
 
@@ -42,7 +42,7 @@ def _to_naive_utc(series: pd.Series) -> pd.Series:
 def _iso_year_week_of(ts: pd.Series) -> tuple[pd.Series, pd.Series]:
     """Restituisce (iso_year, iso_week) da una Series datetime tz-aware."""
 
-    if not pd.api.types.is_datetime64tz_dtype(ts):
+    if not isinstance(ts.dtype, pd.DatetimeTZDtype):
         raise TypeError("La serie deve contenere datetime tz-aware")
 
     iso = ts.dt.isocalendar()

--- a/loader/leaves.py
+++ b/loader/leaves.py
@@ -14,6 +14,8 @@ def load_leaves(
     employees_df: pd.DataFrame,
     shifts_df: pd.DataFrame,
     calendar_df: pd.DataFrame,
+    *,
+    absence_hours_h: float | None = None,
 ) -> tuple[pd.DataFrame, pd.DataFrame]:
     allowed_turns = tuple(
         pd.Series(shifts_df.loc[shifts_df["duration_min"] > 0, "shift_id"])
@@ -76,6 +78,11 @@ def load_leaves(
 
     absences_df = load_absences(path)
 
+    if absence_hours_h is None:
+        absence_hours_h = 6.0
+    else:
+        absence_hours_h = float(absence_hours_h)
+
     known_emp = set(employees_df["employee_id"].astype(str).unique())
     unknown = sorted(set(absences_df["employee_id"].unique()) - known_emp)
     if unknown:
@@ -85,7 +92,8 @@ def load_leaves(
     absences_df["end_date_dt"] = pd.to_datetime(absences_df["date_to"], format="%Y-%m-%d")
     absences_df["tipo"] = absences_df["type"]
     abs_by_day = explode_absences_by_day(
-        absences_df.loc[:, ["employee_id", "date_from", "date_to", "type"]]
+        absences_df.loc[:, ["employee_id", "date_from", "date_to", "type"]],
+        absence_hours_h=absence_hours_h,
     )
 
     shift_info = shifts_df.loc[


### PR DESCRIPTION
## Summary
- propagate the configured payroll.absence_hours_h value into load_leaves and the daily absence expansion
- add a regression test covering custom absence hour propagation to leave days
- refresh gap-pair datetime dtype checks to use DatetimeTZDtype instead of the deprecated helper

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e684a79628832ca236dd0074650483