### PR TITLE
Use contract hour defaults for role baselines

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -13,7 +13,7 @@ defaults:
   contract_hours_by_role_h:
     infermiere: 168
     oss: 168
-    caposala: 168
+    caposala: 150
   night:
     can_work_night: true
     max_per_week: 2
@@ -32,9 +32,6 @@ shift_types:
   night_codes: ["N"]
 payroll:
   absence_hours_h: 6
-  fulltime_hours_mensili_default: 165
-  fulltime_hours_mensili_by_role:
-    caposala: 150
 cross:
   max_shifts_week: 2
   max_shifts_month: 6


### PR DESCRIPTION
## Summary
- remove payroll full-time hour overrides in favour of defaults.contract_hours_by_role_h
- add helpers to read required contract hours per role and reuse them in loaders
- adjust tests and sample config to match the new configuration shape

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e689690be0832c908701c381c920e3