### PR TITLE
Align night fairness with weekend objective logic

### DIFF
--- a/tests/test_night_fairness.py
+++ b/tests/test_night_fairness.py
@@ -6,7 +6,7 @@ import pandas as pd
 import pytest
 
 from src.model import (
-    NIGHT_FAIRNESS_WEIGHT_SCALE,
+    NIGHT_FAIRNESS_OBJECTIVE_SCALE,
     ModelContext,
     _build_night_fairness_objective_terms,
 )
@@ -109,9 +109,13 @@ def _objective_terms_for_weight(weight: float) -> list[tuple[str, int]]:
 def test_night_fairness_adds_weighted_objective_terms() -> None:
     fairness_terms = _objective_terms_for_weight(1.75)
     assert fairness_terms
-    expected_coeff = int(round(1.75 * NIGHT_FAIRNESS_WEIGHT_SCALE))
+    expected_coeff = int(round(1.75 * NIGHT_FAIRNESS_OBJECTIVE_SCALE))
     assert expected_coeff > 0
     assert all(coeff == expected_coeff for _, coeff in fairness_terms)
+    assert {name for name, _ in fairness_terms} == {
+        "night_fair_dev_units_e0_D1",
+        "night_fair_dev_units_e1_D1",
+    }
 
 
 def test_night_fairness_skipped_with_zero_weight() -> None:


### PR DESCRIPTION
## Summary
- align the night fairness objective with the weekend fairness scaling and deviation logic
- reuse the same integer weight scaling and deviation unit construction for night fairness terms
- update the dedicated night fairness unit tests to assert the new coefficients and variables

## Testing
- pytest tests/test_night_fairness.py -q

------
https://chatgpt.com/codex/tasks/task_e_68f5f1fc4740832c8ac5a3105d0bfd0b